### PR TITLE
Support 6-column fragments.tsv.gz (Cellranger-ATAC 2.0+) as well as 5-column 

### DIFF
--- a/R/epiAneufinder_function.R
+++ b/R/epiAneufinder_function.R
@@ -93,7 +93,9 @@ epiAneufinder <- function(input, outdir, blacklist, windowSize, genome="BSgenome
       if(grepl("\\.tsv$|\\.tsv.gz$", input)){
         message("Obtaining the fragments tsv file")
         file_fragments <- fread(input)
-        colnames(file_fragments) <- c('seqnames','start','end','barcode','pcr')
+        # fix for more recent Cellranger-ATAC fragments.tsv.gz files:
+        columns <- c('seqnames','start','end','barcode','pcr','strand')
+        colnames(file_fragments) <- columns[seq_len(ncol(file_fragments))]
         fragments <- as_granges(file_fragments)
         #print(head(fragments))
       } else if(grepl("\\.bed$", input)){


### PR DESCRIPTION
Updated column names to include 'strand' for compatibility with recent Cellranger-ATAC fragments files (6 columns not 5).  If 5 columns are detected, only use the first 5 colnames. 